### PR TITLE
Allow to set Subject Alternative Names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,10 @@ ssl_certs_common_name: "{{ ansible_fqdn }}"
 ssl_certs_san_name: "{{ ssl_certs_common_name }}"
 ssl_certs_email: "local@localhost.local"
 ssl_certs_days: "365"
-ssl_certs_fields: "/C={{ ssl_certs_country }}/ST={{ ssl_certs_state }}/L={{ ssl_certs_locality }}/O={{ ssl_certs_organization }}/CN={{ ssl_certs_common_name }}"
+ssl_certs_san:
+  DNS.1: "{{ ssl_certs_common_name }}"
+  DNS.2: "{{ ssl_certs_san_name }}"
+
 
 ssl_certs_path: "/etc/ssl/{{ ssl_certs_common_name }}"
 ssl_certs_conf_path: "{{ ssl_certs_path }}/{{ ssl_certs_common_name }}.conf"

--- a/templates/sslcert.conf.j2
+++ b/templates/sslcert.conf.j2
@@ -42,5 +42,6 @@ subjectAltName       = @alternate_names
 
 [ alternate_names ]
 
-DNS.1       = {{ ssl_certs_common_name }}
-DNS.2       = {{ ssl_certs_san_name }}
+{% for key, value in ssl_certs_san.items() %}
+{{ key }} = {{ value }}
+{% endfor %}


### PR DESCRIPTION
The `ssl_certs_fields` is not being used anywhere in the playbook - thus we were never able to override the SANs.

I extracted the SANs into their own separate variables.