### PR TITLE
Change include to include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
     when: stat_privkey.stat.exists and not stat_cert.stat.exists
     tags: [ssl-certs,configuration]
 
-  - include: generate.yml
+  - include_tasks: generate.yml
     when: >
       ( not stat_privkey.stat.exists and not stat_cert.stat.exists )
       and ( ssl_certs_local_privkey_data | length == 0 and ssl_certs_local_cert_data | length == 0 )


### PR DESCRIPTION
This is needed to run the playbook after we upgraded the version of Ansible we use.

Here's the error encountered without this.

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```